### PR TITLE
prometheus: fire an alert if any of our SMART metrics is nonzero

### DIFF
--- a/nixos/hosts/hedwig/conf/prometheus/hedwig.yml
+++ b/nixos/hosts/hedwig/conf/prometheus/hedwig.yml
@@ -70,6 +70,15 @@ groups:
         expr: smartctl_device_attribute{attribute_id="197",attribute_value_type="raw"}
       - record: node:disk:offline_uncorrectable:raw
         expr: smartctl_device_attribute{attribute_id="198",attribute_value_type="raw"}
+      - alert: node_disk_smart
+        expr: '{__name__=~"node:disk:[^:]+:raw"} > 0'
+        for: 1m
+        labels:
+          severity: notify
+        annotations:
+          summary: "Drive {{ $labels.device }} reports a SMART issue"
+          description: "{{ $labels.__name__ }} is {{ $value }} for drive {{ $labels.device }}"
+
 
   - name: node_cpu
     rules:


### PR DESCRIPTION
This is a bit crude. Per https://www.backblaze.com/blog/what-smart-stats-indicate-hard-drive-failures/ we probably want to do some sort of rate(...[1d]) computation on most of these metrics (other than 197) and alert off that, rather than just alerting on anything non-zero. In fact, one of my drives (in a mirror, so low risk) as a nonzero value for 187 (reported uncorrectable errors, it reports 10) and that could be something as benign as a bad moment with cosmic rays.